### PR TITLE
Move polling targets to config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ FROM debian:stable-slim
 WORKDIR /app
 COPY --from=backend /server ./server
 COPY --from=frontend /backend/public ./public
+COPY config.json ./config.json
 EXPOSE 8080
 CMD ["./server"]

--- a/README.md
+++ b/README.md
@@ -6,11 +6,20 @@ a graph to the user. OAuth2 authentication can be enabled via environment variab
 
 ## Backend
 
-The backend resides in `backend/` and can be configured using the following environment variables:
+The backend resides in `backend/` and reads its polling target from a JSON configuration file.
+The path can be specified via the `CONFIG_PATH` environment variable (default `config.json`).
+The file should contain:
 
-- `SNMP_HOST` – address of the SNMP device (default `localhost`)
-- `SNMP_COMMUNITY` – SNMP community string (`public`)
-- `SNMP_OID` – OID to query (`.1.3.6.1.2.1.1.3.0`)
+```json
+{
+  "host": "localhost",
+  "community": "public",
+  "oid": ".1.3.6.1.2.1.1.3.0"
+}
+```
+
+Additional options can still be set through environment variables:
+
 - `POLL_INTERVAL` – polling interval (e.g. `30s`)
 - `DB_PATH` – path to the BoltDB file (`data.db`)
 - `ADDR` – HTTP listen address (`:8080`)

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,191 +1,220 @@
 package main
 
 import (
-    "encoding/json"
-    "fmt"
-    "io"
-    "log"
-    "net/http"
-    "net/url"
-    "os"
-    "strings"
-    "time"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
 
-    "github.com/gosnmp/gosnmp"
-    bolt "go.etcd.io/bbolt"
+	"github.com/gosnmp/gosnmp"
+	bolt "go.etcd.io/bbolt"
 )
 
 const bucketName = "samples"
 
 func main() {
-    snmpHost := getEnv("SNMP_HOST", "localhost")
-    snmpCommunity := getEnv("SNMP_COMMUNITY", "public")
-    snmpOID := getEnv("SNMP_OID", ".1.3.6.1.2.1.1.3.0")
-    pollInterval := getEnvDuration("POLL_INTERVAL", time.Minute)
-    dbPath := getEnv("DB_PATH", "data.db")
+	cfgPath := getEnv("CONFIG_PATH", "config.json")
+	cfg := loadPollConfig(cfgPath)
+	snmpHost := cfg.Host
+	snmpCommunity := cfg.Community
+	snmpOID := cfg.OID
+	pollInterval := getEnvDuration("POLL_INTERVAL", time.Minute)
+	dbPath := getEnv("DB_PATH", "data.db")
 
-    db, err := bolt.Open(dbPath, 0600, nil)
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer db.Close()
-    db.Update(func(tx *bolt.Tx) error {
-        _, err := tx.CreateBucketIfNotExists([]byte(bucketName))
-        return err
-    })
+	db, err := bolt.Open(dbPath, 0600, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+		return err
+	})
 
-    go func() {
-        for {
-            poll(snmpHost, snmpCommunity, snmpOID, db)
-            time.Sleep(pollInterval)
-        }
-    }()
+	go func() {
+		for {
+			poll(snmpHost, snmpCommunity, snmpOID, db)
+			time.Sleep(pollInterval)
+		}
+	}()
 
-    http.Handle("/api/data", authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        data := readSamples(db)
-        json.NewEncoder(w).Encode(data)
-    })))
+	http.Handle("/api/data", authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data := readSamples(db)
+		json.NewEncoder(w).Encode(data)
+	})))
 
-    http.Handle("/", http.FileServer(http.Dir("public")))
+	http.Handle("/", http.FileServer(http.Dir("public")))
 
-    addr := getEnv("ADDR", ":8080")
-    log.Printf("Listening on %s", addr)
-    log.Fatal(http.ListenAndServe(addr, nil))
+	addr := getEnv("ADDR", ":8080")
+	log.Printf("Listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
 }
 
 type sample struct {
-    Timestamp int64   `json:"timestamp"`
-    Value     float64 `json:"value"`
+	Timestamp int64   `json:"timestamp"`
+	Value     float64 `json:"value"`
+}
+
+type pollConfig struct {
+	Host      string `json:"host"`
+	Community string `json:"community"`
+	OID       string `json:"oid"`
+}
+
+func loadPollConfig(path string) pollConfig {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("read config: %v", err)
+	}
+	var c pollConfig
+	if err := json.Unmarshal(b, &c); err != nil {
+		log.Fatalf("parse config: %v", err)
+	}
+	if c.Host == "" {
+		c.Host = "localhost"
+	}
+	if c.Community == "" {
+		c.Community = "public"
+	}
+	if c.OID == "" {
+		c.OID = ".1.3.6.1.2.1.1.3.0"
+	}
+	return c
 }
 
 func poll(host, community, oid string, db *bolt.DB) {
-    gs := &gosnmp.GoSNMP{
-        Target:    host,
-        Port:      161,
-        Community: community,
-        Version:   gosnmp.Version2c,
-        Timeout:   time.Duration(2) * time.Second,
-        Retries:   1,
-    }
-    if err := gs.Connect(); err != nil {
-        log.Println("SNMP connect error:", err)
-        return
-    }
-    defer gs.Conn.Close()
-    pdu, err := gs.Get([]string{oid})
-    if err != nil {
-        log.Println("SNMP get error:", err)
-        return
-    }
-    if len(pdu.Variables) == 0 {
-        log.Println("No SNMP variables returned")
-        return
-    }
-    val := float64(toInt(pdu.Variables[0].Value))
-    s := sample{Timestamp: time.Now().Unix(), Value: val}
-    db.Update(func(tx *bolt.Tx) error {
-        b := tx.Bucket([]byte(bucketName))
-        key := []byte(fmt.Sprintf("%d", s.Timestamp))
-        buf, _ := json.Marshal(s)
-        return b.Put(key, buf)
-    })
-    log.Printf("polled: %v", s)
+	gs := &gosnmp.GoSNMP{
+		Target:    host,
+		Port:      161,
+		Community: community,
+		Version:   gosnmp.Version2c,
+		Timeout:   time.Duration(2) * time.Second,
+		Retries:   1,
+	}
+	if err := gs.Connect(); err != nil {
+		log.Println("SNMP connect error:", err)
+		return
+	}
+	defer gs.Conn.Close()
+	pdu, err := gs.Get([]string{oid})
+	if err != nil {
+		log.Println("SNMP get error:", err)
+		return
+	}
+	if len(pdu.Variables) == 0 {
+		log.Println("No SNMP variables returned")
+		return
+	}
+	val := float64(toInt(pdu.Variables[0].Value))
+	s := sample{Timestamp: time.Now().Unix(), Value: val}
+	db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		key := []byte(fmt.Sprintf("%d", s.Timestamp))
+		buf, _ := json.Marshal(s)
+		return b.Put(key, buf)
+	})
+	log.Printf("polled: %v", s)
 }
 
 func readSamples(db *bolt.DB) []sample {
-    samples := []sample{}
-    db.View(func(tx *bolt.Tx) error {
-        b := tx.Bucket([]byte(bucketName))
-        b.ForEach(func(k, v []byte) error {
-            var s sample
-            if err := json.Unmarshal(v, &s); err == nil {
-                samples = append(samples, s)
-            }
-            return nil
-        })
-        return nil
-    })
-    return samples
+	samples := []sample{}
+	db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		b.ForEach(func(k, v []byte) error {
+			var s sample
+			if err := json.Unmarshal(v, &s); err == nil {
+				samples = append(samples, s)
+			}
+			return nil
+		})
+		return nil
+	})
+	return samples
 }
 
 func getEnv(key, def string) string {
-    if v := os.Getenv(key); v != "" {
-        return v
-    }
-    return def
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
 }
 
 func getEnvDuration(key string, def time.Duration) time.Duration {
-    if v := os.Getenv(key); v != "" {
-        if d, err := time.ParseDuration(v); err == nil {
-            return d
-        }
-    }
-    return def
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
 }
 
 func toInt(v interface{}) int64 {
-    switch t := v.(type) {
-    case int:
-        return int64(t)
-    case uint:
-        return int64(t)
-    case int64:
-        return t
-    case uint64:
-        return int64(t)
-    case int32:
-        return int64(t)
-    case uint32:
-        return int64(t)
-    case float64:
-        return int64(t)
-    default:
-        return 0
-    }
+	switch t := v.(type) {
+	case int:
+		return int64(t)
+	case uint:
+		return int64(t)
+	case int64:
+		return t
+	case uint64:
+		return int64(t)
+	case int32:
+		return int64(t)
+	case uint32:
+		return int64(t)
+	case float64:
+		return int64(t)
+	default:
+		return 0
+	}
 }
 
 // authMiddleware performs a simple OAuth2 token introspection if configured.
 func authMiddleware(next http.Handler) http.Handler {
-    introspectURL := os.Getenv("OAUTH2_INTROSPECT_URL")
-    clientID := os.Getenv("OAUTH2_CLIENT_ID")
-    clientSecret := os.Getenv("OAUTH2_CLIENT_SECRET")
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        auth := r.Header.Get("Authorization")
-        if introspectURL == "" {
-            next.ServeHTTP(w, r)
-            return
-        }
-        if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
-            http.Error(w, "unauthorized", http.StatusUnauthorized)
-            return
-        }
-        token := strings.TrimPrefix(auth, "Bearer ")
-        form := url.Values{}
-        form.Set("token", token)
-        req, err := http.NewRequest("POST", introspectURL, strings.NewReader(form.Encode()))
-        if err != nil {
-            http.Error(w, "server error", http.StatusInternalServerError)
-            return
-        }
-        req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-        if clientID != "" {
-            req.SetBasicAuth(clientID, clientSecret)
-        }
-        resp, err := http.DefaultClient.Do(req)
-        if err != nil {
-            http.Error(w, "auth error", http.StatusUnauthorized)
-            return
-        }
-        defer resp.Body.Close()
-        body, _ := io.ReadAll(resp.Body)
-        var result struct{
-            Active bool `json:"active"`
-        }
-        if err := json.Unmarshal(body, &result); err != nil || !result.Active {
-            http.Error(w, "unauthorized", http.StatusUnauthorized)
-            return
-        }
-        next.ServeHTTP(w, r)
-    })
+	introspectURL := os.Getenv("OAUTH2_INTROSPECT_URL")
+	clientID := os.Getenv("OAUTH2_CLIENT_ID")
+	clientSecret := os.Getenv("OAUTH2_CLIENT_SECRET")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if introspectURL == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		token := strings.TrimPrefix(auth, "Bearer ")
+		form := url.Values{}
+		form.Set("token", token)
+		req, err := http.NewRequest("POST", introspectURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			http.Error(w, "server error", http.StatusInternalServerError)
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if clientID != "" {
+			req.SetBasicAuth(clientID, clientSecret)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			http.Error(w, "auth error", http.StatusUnauthorized)
+			return
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		var result struct {
+			Active bool `json:"active"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil || !result.Active {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "host": "localhost",
+  "community": "public",
+  "oid": ".1.3.6.1.2.1.1.3.0"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SNMP_HOST: "localhost"
-      SNMP_COMMUNITY: "public"
-      SNMP_OID: ".1.3.6.1.2.1.1.3.0"
+      CONFIG_PATH: "/config/config.json"
       POLL_INTERVAL: "1m"
       DB_PATH: "/data/data.db"
     volumes:
       - data:/data
+      - ./config.json:/config/config.json:ro
 volumes:
   data:


### PR DESCRIPTION
## Summary
- load SNMP host, community and OID from a JSON config file
- document new config file in the README
- mount config.json in docker-compose
- bundle config.json in the Docker image

## Testing
- `cd backend && gofmt -w main.go && go build ./...`
- `cd frontend && npm install`


------
https://chatgpt.com/codex/tasks/task_e_68761d499eec832ba872edd6c3868b5b