### PR TITLE
Update Go to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY frontend/src ./src
 RUN npm install && npm run build
 
 # backend build
-FROM golang:1.21 AS backend
+FROM golang:1.23 AS backend
 WORKDIR /app
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module grapher
 
-go 1.21
+go 1.23
 
 require (
 	github.com/gosnmp/gosnmp v1.36.0


### PR DESCRIPTION
## Summary
- bump Go version in `go.mod`
- use Go 1.23 for backend build stage in Dockerfile

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877637c34fc832bafbfa23a003b715a