### PR TITLE
Dashboard for all graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Static frontend files are served from `backend/public`.
 ## Frontend
 
 A simple Svelte application in `frontend/` uses D3 to plot the time series returned from `/api/data`.
+It renders a dashboard where all configured sources are shown on their own chart simultaneously.
 Run `npm install` and `npm run build` in the `frontend` directory to build the assets. They will be
 placed into `backend/public` and served by the Go backend.
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,37 +3,54 @@
   import * as d3 from 'd3';
 
   let datasets = {};
-  let selected = '';
+  const svgs = {};
 
   async function fetchData() {
-    const res = await fetch('/api/data', {headers: {'Authorization': localStorage.getItem('token') || ''}});
+    const res = await fetch('/api/data', {
+      headers: { Authorization: localStorage.getItem('token') || '' }
+    });
     datasets = await res.json();
-    if (!selected && Object.keys(datasets).length) {
-      selected = Object.keys(datasets)[0];
-    }
-    draw();
+    drawAll();
   }
 
-  let svg;
-  function draw() {
+  function slug(name) {
+    return name.replace(/[^a-zA-Z0-9_-]+/g, '_');
+  }
+
+  function draw(name) {
+    let svg = svgs[name];
     if (!svg) {
-      svg = d3.select('#chart').append('svg').attr('width', 600).attr('height', 300);
+      svg = d3
+        .select(`#chart-${slug(name)}`)
+        .append('svg')
+        .attr('width', 600)
+        .attr('height', 300);
+      svgs[name] = svg;
     }
     svg.selectAll('*').remove();
-    const data = datasets[selected] || [];
+    const data = datasets[name] || [];
     if (!data.length) return;
     const x = d3.scaleTime().range([0, 580]);
     const y = d3.scaleLinear().range([280, 0]);
-    data.forEach(d => { d.date = new Date(d.timestamp * 1000); });
+    data.forEach(d => {
+      d.date = new Date(d.timestamp * 1000);
+    });
     x.domain(d3.extent(data, d => d.date));
     y.domain([0, d3.max(data, d => d.value)]);
-    const line = d3.line()
+    const line = d3
+      .line()
       .x(d => x(d.date))
       .y(d => y(d.value));
-    svg.append('path').datum(data).attr('fill', 'none').attr('stroke', 'steelblue').attr('d', line);
+    svg
+      .append('path')
+      .datum(data)
+      .attr('fill', 'none')
+      .attr('stroke', 'steelblue')
+      .attr('d', line);
     svg.append('g').attr('transform', 'translate(0,280)').call(d3.axisBottom(x));
     svg.append('g').call(d3.axisLeft(y));
-    svg.append('text')
+    svg
+      .append('text')
       .attr('transform', 'rotate(-90)')
       .attr('y', 15)
       .attr('x', -140)
@@ -41,14 +58,25 @@
       .text('Temperature');
   }
 
+  function drawAll() {
+    Object.keys(datasets).forEach(draw);
+  }
+
   onMount(fetchData);
 </script>
 
-<div id="chart"></div>
-
-<select bind:value={selected} on:change={draw}>
+<div id="charts">
   {#each Object.keys(datasets) as name}
-    <option value={name}>{name}</option>
+    <div class="chart-container">
+      <h3>{name}</h3>
+      <div id={"chart-" + slug(name)}></div>
+    </div>
   {/each}
-</select>
+</div>
 <button on:click={fetchData}>Refresh</button>
+
+<style>
+  .chart-container {
+    margin-bottom: 2rem;
+  }
+</style>


### PR DESCRIPTION
## Summary
- show a graph for each source in a dashboard
- document dashboard behaviour in README

## Testing
- `npm run build`
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687eb920bd58832bbf889d10ec145b80