### PR TITLE
Add units and type configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ The file should list one or more polling sources:
 {
   "sources": [
     {
+      "name": "Internal sensor",
       "host": "localhost",
       "community": "public",
-      "oid": ".1.3.6.1.2.1.1.3.0"
+      "oid": ".1.3.6.1.2.1.1.3.0",
+      "units": "C",
+      "type": "temperature"
     }
   ]
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -65,6 +65,8 @@ type pollSource struct {
 	Host      string `json:"host"`
 	Community string `json:"community"`
 	OID       string `json:"oid"`
+	Units     string `json:"units,omitempty"`
+	Type      string `json:"type,omitempty"`
 }
 
 type pollConfig struct {

--- a/config.json
+++ b/config.json
@@ -4,19 +4,25 @@
       "name": "Internal sensor",
       "host": "192.168.1.253",
       "community": "public",
-      "oid": "1.3.6.1.4.1.20916.1.10.1.1.1.0"
+      "oid": "1.3.6.1.4.1.20916.1.10.1.1.1.0",
+      "units": "C",
+      "type": "temperature"
     },
     {
       "name": "External sensor - Temp",
       "host": "192.168.1.253",
       "community": "public",
-      "oid": "1.3.6.1.4.1.20916.1.10.1.2.1.0"
+      "oid": "1.3.6.1.4.1.20916.1.10.1.2.1.0",
+      "units": "C",
+      "type": "temperature"
     },
     {
       "name": "External sensor - Relative Humidity",
       "host": "192.168.1.253",
       "community": "public",
-      "oid": "1.3.6.1.4.1.20916.1.10.1.2.3.0"
+      "oid": "1.3.6.1.4.1.20916.1.10.1.2.3.0",
+      "units": "%",
+      "type": "humidity"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add optional `units` and `type` fields in `pollSource`
- document new options in `README`
- update example `config.json` with units and type values

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f560ac398832b94d00877f82a9c9c