### PR TITLE
Fix invalid CSS selector generation

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,7 +11,7 @@
   }
 
   function safeId(name) {
-    return encodeURIComponent(name);
+    return name.replace(/[^A-Za-z0-9_-]/g, '_');
   }
 
   function drawAll() {


### PR DESCRIPTION
## Summary
- sanitize dataset names used as element IDs

## Testing
- `npm run build`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f57f99234832bb8b5077b17d51560