### PR TITLE
Add database maintenance tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,13 @@ WORKDIR /app
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 COPY backend ./backend
-RUN cd backend && go build -o /server
+RUN cd backend && go build -o /server && go build -o /dbtool ./cmd/dbtool
 
 # final image
 FROM debian:stable-slim
 WORKDIR /app
 COPY --from=backend /server ./server
+COPY --from=backend /dbtool ./dbtool
 COPY --from=frontend /backend/public ./public
 COPY config.json ./config.json
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@ docker compose up
 ```
 
 This will build the image and run the service on port 8080 while persisting the database in a named volume.
+
+## Database maintenance
+
+The Docker image ships with a `dbtool` helper that can modify the BoltDB file used by the backend. It supports renaming, deleting and merging data sources. The tool accepts the same `DB_PATH` environment variable as the server or a custom path via the `-db` flag.
+
+Examples:
+
+```sh
+docker run --rm -v data:/data grapher ./dbtool rename old_name new_name
+```
+

--- a/backend/cmd/dbtool/main.go
+++ b/backend/cmd/dbtool/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const bucketName = "samples"
+
+type sample struct {
+	Timestamp int64   `json:"timestamp"`
+	Value     float64 `json:"value"`
+	Source    string  `json:"source"`
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+	cmd := os.Args[1]
+
+	dbPath := flag.String("db", getEnv("DB_PATH", "data.db"), "path to database")
+	flag.CommandLine.Parse(os.Args[2:])
+
+	db, err := bolt.Open(*dbPath, 0600, nil)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	switch cmd {
+	case "rename":
+		if flag.NArg() != 2 {
+			usage()
+			os.Exit(1)
+		}
+		from, to := flag.Arg(0), flag.Arg(1)
+		if err := renameSource(db, from, to); err != nil {
+			log.Fatalf("rename: %v", err)
+		}
+	case "delete":
+		if flag.NArg() != 1 {
+			usage()
+			os.Exit(1)
+		}
+		name := flag.Arg(0)
+		if err := deleteSource(db, name); err != nil {
+			log.Fatalf("delete: %v", err)
+		}
+	case "merge":
+		if flag.NArg() != 2 {
+			usage()
+			os.Exit(1)
+		}
+		from, to := flag.Arg(0), flag.Arg(1)
+		if err := mergeSource(db, from, to); err != nil {
+			log.Fatalf("merge: %v", err)
+		}
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func renameSource(db *bolt.DB, from, to string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		if b == nil {
+			return fmt.Errorf("bucket %s not found", bucketName)
+		}
+		src := b.Bucket([]byte(from))
+		if src == nil {
+			return fmt.Errorf("source %s not found", from)
+		}
+		dest, err := b.CreateBucket([]byte(to))
+		if err != nil {
+			return err
+		}
+		if err := src.ForEach(func(k, v []byte) error {
+			var s sample
+			if err := json.Unmarshal(v, &s); err == nil {
+				s.Source = to
+				if nb, err := json.Marshal(s); err == nil {
+					v = nb
+				}
+			}
+			return dest.Put(k, v)
+		}); err != nil {
+			return err
+		}
+		if err := b.DeleteBucket([]byte(from)); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func deleteSource(db *bolt.DB, name string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		if b == nil {
+			return fmt.Errorf("bucket %s not found", bucketName)
+		}
+		return b.DeleteBucket([]byte(name))
+	})
+}
+
+func mergeSource(db *bolt.DB, from, to string) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		if b == nil {
+			return fmt.Errorf("bucket %s not found", bucketName)
+		}
+		src := b.Bucket([]byte(from))
+		if src == nil {
+			return fmt.Errorf("source %s not found", from)
+		}
+		dest, err := b.CreateBucketIfNotExists([]byte(to))
+		if err != nil {
+			return err
+		}
+		if err := src.ForEach(func(k, v []byte) error {
+			var s sample
+			if err := json.Unmarshal(v, &s); err == nil {
+				s.Source = to
+				if nb, err := json.Marshal(s); err == nil {
+					v = nb
+				}
+			}
+			return dest.Put(k, v)
+		}); err != nil {
+			return err
+		}
+		return b.DeleteBucket([]byte(from))
+	})
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  dbtool [flags] rename <from> <to>")
+	fmt.Fprintln(os.Stderr, "  dbtool [flags] delete <name>")
+	fmt.Fprintln(os.Stderr, "  dbtool [flags] merge <from> <to>")
+	flag.PrintDefaults()
+}
+
+func getEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}


### PR DESCRIPTION
## Summary
- add `dbtool` command for database maintenance
- build and ship `dbtool` in Docker image
- document the tool in README

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f646e1e3c832bacc7e79d7d0f71cd