### PR TITLE
Add list command to dbtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ This will build the image and run the service on port 8080 while persisting the 
 
 ## Database maintenance
 
-The Docker image ships with a `dbtool` helper that can modify the BoltDB file used by the backend. It supports renaming, deleting and merging data sources. The tool accepts the same `DB_PATH` environment variable as the server or a custom path via the `-db` flag.
+The Docker image ships with a `dbtool` helper that can modify the BoltDB file used by the backend. It supports renaming, deleting, merging and listing data sources. The tool accepts the same `DB_PATH` environment variable as the server or a custom path via the `-db` flag.
 
 Examples:
 
 ```sh
 docker run --rm -v data:/data grapher ./dbtool rename old_name new_name
+docker run --rm -v data:/data grapher ./dbtool list
 ```
 

--- a/backend/cmd/dbtool/main.go
+++ b/backend/cmd/dbtool/main.go
@@ -62,6 +62,14 @@ func main() {
 		if err := mergeSource(db, from, to); err != nil {
 			log.Fatalf("merge: %v", err)
 		}
+	case "list":
+		if flag.NArg() != 0 {
+			usage()
+			os.Exit(1)
+		}
+		if err := listSources(db); err != nil {
+			log.Fatalf("list: %v", err)
+		}
 	default:
 		usage()
 		os.Exit(1)
@@ -141,11 +149,28 @@ func mergeSource(db *bolt.DB, from, to string) error {
 	})
 }
 
+func listSources(db *bolt.DB) error {
+	return db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucketName))
+		if b == nil {
+			return fmt.Errorf("bucket %s not found", bucketName)
+		}
+		return b.ForEach(func(k, v []byte) error {
+			if v != nil {
+				return nil
+			}
+			fmt.Println(string(k))
+			return nil
+		})
+	})
+}
+
 func usage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
 	fmt.Fprintln(os.Stderr, "  dbtool [flags] rename <from> <to>")
 	fmt.Fprintln(os.Stderr, "  dbtool [flags] delete <name>")
 	fmt.Fprintln(os.Stderr, "  dbtool [flags] merge <from> <to>")
+	fmt.Fprintln(os.Stderr, "  dbtool [flags] list")
 	flag.PrintDefaults()
 }
 


### PR DESCRIPTION
## Summary
- expose `list` command in `dbtool` to show source names
- document the new command in the README

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_687f693530e4832b9c5f36a7bc4cadbd