### PR TITLE
Adjust y-axis padding in graph

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -40,7 +40,10 @@
       const y = d3.scaleLinear().range([height, 0]);
       data.forEach(d => { d.date = new Date(d.timestamp * 1000); });
       x.domain(d3.extent(data, d => d.date));
-      y.domain([0, d3.max(data, d => d.value * scale)]);
+      const minVal = d3.min(data, d => d.value * scale);
+      const maxVal = d3.max(data, d => d.value * scale);
+      const padding = (maxVal - minVal) * 0.1;
+      y.domain([minVal - padding, maxVal + padding]);
       const line = d3.line()
         .x(d => x(d.date))
         .y(d => y(d.value * scale));


### PR DESCRIPTION
## Summary
- adjust D3 y-axis scale to include 10% padding
- rebuild frontend assets

## Testing
- `npm run build`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f6ce1b918832b806e32cc4ea25c6e