### PR TITLE
Fix dbtool hang on locked DB

### DIFF
--- a/backend/cmd/dbtool/main.go
+++ b/backend/cmd/dbtool/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	bolt "go.etcd.io/bbolt"
 )
@@ -30,7 +31,11 @@ func main() {
 
 	fmt.Printf("Try to open: %s    ----> ", *dbPath)
 
-	db, err := bolt.Open(*dbPath, 0600, nil)
+	// BoltDB obtains an exclusive file lock when opening the database.
+	// Without a timeout this call blocks indefinitely if another process
+	// already holds the lock (e.g. the server is running). Set a small
+	// timeout so we fail fast instead of hanging.
+	db, err := bolt.Open(*dbPath, 0600, &bolt.Options{Timeout: time.Second})
 	if err != nil {
 		log.Fatalf("open db: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update dbtool to use a 1-second timeout when opening BoltDB

## Testing
- `go build ./cmd/dbtool`

------
https://chatgpt.com/codex/tasks/task_e_687f7369aa9c832b8c95cd2ce2d7800f