### PR TITLE
Add REST-based dbtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ This will build the image and run the service on port 8080 while persisting the 
 
 ## Database maintenance
 
-The Docker image ships with a `dbtool` helper that can modify the BoltDB file used by the backend. It supports renaming, deleting, merging and listing data sources. The tool accepts the same `DB_PATH` environment variable as the server or a custom path via the `-db` flag.
+The Docker image ships with a `dbtool` helper that can modify the database via the running server. It supports renaming, deleting, merging and listing data sources. The tool sends REST requests to the backend and therefore requires the server to be running. The target server can be specified with the `-addr` flag or `SERVER_ADDR` environment variable (default `http://localhost:8080`).
 
 Examples:
 
 ```sh
-docker run --rm -v data:/data grapher ./dbtool rename old_name new_name
-docker run --rm -v data:/data grapher ./dbtool list
+docker run --rm --network host grapher ./dbtool rename old_name new_name
+docker run --rm --network host grapher ./dbtool list
 ```
 


### PR DESCRIPTION
## Summary
- expose DB maintenance REST APIs in backend
- rewrite dbtool to call backend APIs
- update documentation for new dbtool usage

## Testing
- `go fmt ./...`
- `go build ./...`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f77dcf810832b8eca8b689c9e3b82