### PR TITLE
Fix y-axis label placement

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -56,10 +56,8 @@
       if (units) details.push(units);
       if (details.length) label += ` (${details.join(' ')})`;
       g.append('text')
-        .attr('transform', 'rotate(-90)')
-        .attr('y', -margin.left)
-        .attr('x', -height / 2)
-        .attr('dy', '1em')
+        .attr('x', width / 2)
+        .attr('y', height + margin.bottom + 15)
         .attr('text-anchor', 'middle')
         .text(label);
     }
@@ -86,10 +84,8 @@
     const yLabel = labelParts.join(' ');
 
     g.append('text')
-      .attr('transform', 'rotate(-90)')
-      .attr('y', -margin.left)
-      .attr('x', -height / 2)
-      .attr('dy', '1em')
+      .attr('x', width / 2)
+      .attr('y', height + margin.bottom + 15)
       .attr('text-anchor', 'middle')
       .text(yLabel);
 


### PR DESCRIPTION
## Summary
- move the y-axis labels horizontally below the chart to avoid the tick marks

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688003e01620832b95a719a68e5eb671