### PR TITLE
Add SNMP version support in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a graph to the user. OAuth2 authentication can be enabled via environment variab
 
 The backend resides in `backend/` and reads its polling targets from a JSON configuration file.
 The path can be specified via the `CONFIG_PATH` environment variable (default `config.json`).
-The file should list one or more polling sources:
+The file should list one or more polling sources. Each source can optionally define a `version` field to select the SNMP protocol version (supported values are `1` and `2c`; default is `1`):
 
 ```json
 {
@@ -18,6 +18,7 @@ The file should list one or more polling sources:
       "host": "localhost",
       "community": "public",
       "oid": ".1.3.6.1.2.1.1.3.0",
+      "version": "2c",
       "units": "C",
       "type": "temperature"
     }

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
       "host": "192.168.1.253",
       "community": "public",
       "oid": "1.3.6.1.4.1.20916.1.10.1.1.1.0",
+      "version": "2c",
       "units": "C",
       "type": "temperature"
     },
@@ -13,6 +14,7 @@
       "host": "192.168.1.253",
       "community": "public",
       "oid": "1.3.6.1.4.1.20916.1.10.1.2.1.0",
+      "version": "2c",
       "units": "C",
       "type": "temperature"
     },
@@ -21,6 +23,7 @@
       "host": "192.168.1.253",
       "community": "public",
       "oid": "1.3.6.1.4.1.20916.1.10.1.2.3.0",
+      "version": "2c",
       "units": "%",
       "type": "humidity"
     }


### PR DESCRIPTION
## Summary
- allow specifying SNMP version for each source
- document the new `version` field
- update example config

## Testing
- `go vet ./...`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688009fda05c832b8f9edbdf42b7d4ea