### PR TITLE
Add comparison graph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ The file should list one or more polling sources. Each source can optionally def
 }
 ```
 
+You can optionally define comparison graphs which combine multiple sources in a
+single plot:
+
+```json
+{
+  "sources": [
+    { "name": "Internal sensor", ... }
+  ],
+  "graphs": [
+    { "name": "Inside vs Outside", "sources": ["Internal sensor", "External sensor"] }
+  ]
+}
+```
+
 Additional options can still be set through environment variables:
 
 - `POLL_INTERVAL` – polling interval (e.g. `30s`)

--- a/config.json
+++ b/config.json
@@ -27,5 +27,14 @@
       "units": "%",
       "type": "humidity"
     }
+  ],
+  "graphs": [
+    {
+      "name": "Inside vs Outside Temp",
+      "sources": [
+        "Internal sensor - Temp(C)",
+        "External sensor - Temp(C)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add optional `graphs` section in config.json
- compute combined graph data in the backend
- update frontend renderer to handle multi-source datasets
- document new configuration in README

## Testing
- `go vet ./...`
- `go build ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68808dc69908832b8d10a2846a086dc2