### PR TITLE
Add configurable source colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ The file should list one or more polling sources. Each source can optionally def
       "oid": ".1.3.6.1.2.1.1.3.0",
       "version": "2c",
       "units": "C",
-      "type": "temperature"
+      "type": "temperature",
+      "color": "#ff0000"
     }
   ]
 }
 ```
+The optional `color` field controls the colour used for this source when drawing graphs.
+Any CSS colour value is allowed.
 
 You can optionally define comparison graphs which combine multiple sources in a
 single plot:

--- a/backend/main.go
+++ b/backend/main.go
@@ -51,6 +51,9 @@ func main() {
                                 if sourceName(src) == name {
                                         ds.Units = src.Units
                                         ds.Type = src.Type
+                                        if src.Color != "" {
+                                                ds.Colors = map[string]string{name: src.Color}
+                                        }
                                         break
                                 }
                         }
@@ -58,13 +61,23 @@ func main() {
                 }
                 for _, g := range cfg.Graphs {
                         var combined []sample
+                        var colors map[string]string
                         for _, srcName := range g.Sources {
                                 if d, ok := samples[srcName]; ok {
                                         combined = append(combined, d...)
+                                        for _, src := range cfg.Sources {
+                                                if sourceName(src) == srcName && src.Color != "" {
+                                                        if colors == nil {
+                                                                colors = map[string]string{}
+                                                        }
+                                                        colors[srcName] = src.Color
+                                                        break
+                                                }
+                                        }
                                 }
                         }
                         if len(combined) > 0 {
-                                result[g.Name] = dataset{Data: combined}
+                                result[g.Name] = dataset{Data: combined, Colors: colors}
                         }
                 }
                 json.NewEncoder(w).Encode(result)
@@ -146,19 +159,21 @@ type sample struct {
 }
 
 type dataset struct {
-	Units string   `json:"units,omitempty"`
-	Type  string   `json:"type,omitempty"`
-	Data  []sample `json:"data"`
+        Units  string            `json:"units,omitempty"`
+        Type   string            `json:"type,omitempty"`
+        Data   []sample          `json:"data"`
+        Colors map[string]string `json:"colors,omitempty"`
 }
 
 type pollSource struct {
-	Name      string `json:"name"`
-	Host      string `json:"host"`
-	Community string `json:"community"`
-	OID       string `json:"oid"`
-	Units     string `json:"units,omitempty"`
-	Type      string `json:"type,omitempty"`
-	Version   string `json:"version,omitempty"`
+        Name      string `json:"name"`
+        Host      string `json:"host"`
+        Community string `json:"community"`
+        OID       string `json:"oid"`
+        Units     string `json:"units,omitempty"`
+        Type      string `json:"type,omitempty"`
+        Version   string `json:"version,omitempty"`
+        Color     string `json:"color,omitempty"`
 }
 
 type pollConfig struct {

--- a/config.json
+++ b/config.json
@@ -7,26 +7,29 @@
       "oid": "1.3.6.1.4.1.20916.1.10.1.1.1.0",
       "version": "1",
       "units": "C",
-      "type": "temperature"
-    },
-    {
-      "name": "External sensor - Temp(C)",
+      "type": "temperature",
+      "color": "#ff0000"
+      },
+      {
+        "name": "External sensor - Temp(C)",
       "host": "192.168.1.253",
       "community": "public",
       "oid": "1.3.6.1.4.1.20916.1.10.1.2.1.0",
       "version": "1",
       "units": "C",
-      "type": "temperature"
-    },
-    {
-      "name": "External sensor - Relative Humidity(%)",
+      "type": "temperature",
+      "color": "#0000ff"
+      },
+      {
+        "name": "External sensor - Relative Humidity(%)",
       "host": "192.168.1.253",
       "community": "public",
       "oid": "1.3.6.1.4.1.20916.1.10.1.2.3.0",
       "version": "1",
       "units": "%",
-      "type": "humidity"
-    }
+      "type": "humidity",
+      "color": "#00aa00"
+      }
   ],
   "graphs": [
     {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -34,7 +34,7 @@
     const width = 600 - margin.left - margin.right;
     const height = 300 - margin.top - margin.bottom;
     const scale = 0.01; // sensor values are 100x larger than the displayed units
-    const color = d3.scaleOrdinal(d3.schemeCategory10);
+    const defaultColor = d3.scaleOrdinal(d3.schemeCategory10);
 
     for (const [name, info] of Object.entries(datasets)) {
       const data = info.data || [];
@@ -65,13 +65,15 @@
 
       const sources = Array.from(new Set(data.map(d => d.source)));
       if (sources.length > 1) {
-        color.domain(sources);
         const groups = d3.group(data, d => d.source);
         for (const [src, values] of groups) {
-          g.append('path').datum(values).attr('fill', 'none').attr('stroke', color(src)).attr('d', line);
+          let c = (info.colors && info.colors[src]) ? info.colors[src] : defaultColor(src);
+          g.append('path').datum(values).attr('fill', 'none').attr('stroke', c).attr('d', line);
         }
       } else {
-        g.append('path').datum(data).attr('fill', 'none').attr('stroke', 'steelblue').attr('d', line);
+        const src = sources[0];
+        let c = (info.colors && info.colors[src]) ? info.colors[src] : 'steelblue';
+        g.append('path').datum(data).attr('fill', 'none').attr('stroke', c).attr('d', line);
       }
 
       g.append('g').attr('transform', `translate(0,${height})`).call(d3.axisBottom(x));


### PR DESCRIPTION
## Summary
- allow specifying a `color` for each source in `config.json`
- expose source colours from the backend API
- honour configured colours when rendering charts
- document the new option

## Testing
- `npm install`
- `npm run build`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688094fb060c832ba9d0ee76de7c0420