### PR TITLE
Add per-graph timespan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The optional `color` field controls the colour used for this source when drawing
 Any CSS colour value is allowed.
 
 You can optionally define comparison graphs which combine multiple sources in a
-single plot:
+single plot. Each graph may also specify a `timespan` field limiting how much
+historical data is returned. The value is a Go style duration such as `24h`:
 
 ```json
 {
@@ -38,7 +39,11 @@ single plot:
     { "name": "Internal sensor", ... }
   ],
   "graphs": [
-    { "name": "Inside vs Outside", "sources": ["Internal sensor", "External sensor"] }
+    {
+      "name": "Inside vs Outside",
+      "sources": ["Internal sensor", "External sensor"],
+      "timespan": "24h"
+    }
   ]
 }
 ```

--- a/config.json
+++ b/config.json
@@ -37,13 +37,15 @@
       "sources": [
         "Internal sensor - Temp(C)",
         "External sensor - Temp(C)"
-      ]
+      ],
+      "timespan": "24h"
     },{
       "name": "Outside Temp vs Humidity",
       "sources": [
         "External sensor - Temp(C)",
         "External sensor - Relative Humidity(%)"
-      ]
+      ],
+      "timespan": "24h"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- document optional `timespan` field for graph definitions
- update sample configuration with `timespan`
- support `timespan` in backend graph definition and apply filtering

## Testing
- `go test ./...`
- `go vet ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68809df4b744832bacf88ba87c6e308c