### PR TITLE
Add cumulative value support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The file should list one or more polling sources. Each source can optionally def
       "community": "public",
       "oid": ".1.3.6.1.2.1.1.3.0",
       "version": "2c",
+      "cumulative": false,
       "units": "C",
       "type": "temperature",
       "color": "#ff0000"
@@ -28,6 +29,8 @@ The file should list one or more polling sources. Each source can optionally def
 ```
 The optional `color` field controls the colour used for this source when drawing graphs.
 Any CSS colour value is allowed.
+Set `cumulative` to `true` for sources that report a running total instead of a current value.
+For such sources the graph will display the difference between successive samples.
 
 You can optionally define comparison graphs which combine multiple sources in a
 single plot. Each graph may also specify a `timespan` field limiting how much

--- a/backend/main.go
+++ b/backend/main.go
@@ -48,15 +48,24 @@ func main() {
 		for _, g := range cfg.Graphs {
 			var combined []sample
 			var colors map[string]string
+			var cum map[string]bool
 			for _, srcName := range g.Sources {
 				if d, ok := samples[srcName]; ok {
 					combined = append(combined, d...)
 					for _, src := range cfg.Sources {
-						if sourceName(src) == srcName && src.Color != "" {
-							if colors == nil {
-								colors = map[string]string{}
+						if sourceName(src) == srcName {
+							if src.Color != "" {
+								if colors == nil {
+									colors = map[string]string{}
+								}
+								colors[srcName] = src.Color
 							}
-							colors[srcName] = src.Color
+							if src.Cum {
+								if cum == nil {
+									cum = map[string]bool{}
+								}
+								cum[srcName] = true
+							}
 							break
 						}
 					}
@@ -75,7 +84,7 @@ func main() {
 				}
 			}
 			if len(combined) > 0 {
-				result[g.Name] = dataset{Data: combined, Colors: colors}
+				result[g.Name] = dataset{Data: combined, Colors: colors, Cum: cum}
 			}
 		}
 		json.NewEncoder(w).Encode(result)
@@ -161,6 +170,7 @@ type dataset struct {
 	Type   string            `json:"type,omitempty"`
 	Data   []sample          `json:"data"`
 	Colors map[string]string `json:"colors,omitempty"`
+	Cum    map[string]bool   `json:"cumulative,omitempty"`
 }
 
 type pollSource struct {
@@ -172,6 +182,7 @@ type pollSource struct {
 	Type      string `json:"type,omitempty"`
 	Version   string `json:"version,omitempty"`
 	Color     string `json:"color,omitempty"`
+	Cum       bool   `json:"cumulative,omitempty"`
 }
 
 type pollConfig struct {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -37,7 +37,23 @@
     const defaultColor = d3.scaleOrdinal(d3.schemeCategory10);
 
     for (const [name, info] of Object.entries(datasets)) {
-      const data = info.data || [];
+      let data = info.data || [];
+      const cumulative = info.cumulative || {};
+      if (Object.keys(cumulative).length) {
+        const grouped = d3.group(data, d => d.source);
+        const transformed = [];
+        for (const [src, values] of grouped) {
+          if (cumulative[src]) {
+            values.sort((a, b) => a.timestamp - b.timestamp);
+            for (let i = 1; i < values.length; i++) {
+              transformed.push({ ...values[i], value: values[i].value - values[i-1].value });
+            }
+          } else {
+            transformed.push(...values);
+          }
+        }
+        data = transformed;
+      }
       const units = info.units || '';
       const type = info.type || '';
       let container = d3.select(`#chart-${safeId(name)}`);


### PR DESCRIPTION
## Summary
- add a `cumulative` field to data source configuration
- expose cumulative status through the API
- render differences for cumulative sources in the UI
- document cumulative sources in the README

## Testing
- `npm install`
- `npm run build`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880aecf98ec832bae434355cfa35a4a