### PR TITLE
Support graph groups via YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ a graph to the user. OAuth2 authentication can be enabled via environment variab
 
 ## Backend
 
-The backend resides in `backend/` and reads its polling targets from a JSON configuration file.
-The path can be specified via the `CONFIG_PATH` environment variable (default `config.json`).
+The backend resides in `backend/` and reads its polling targets from a configuration file.
+Both JSON and YAML formats are supported. The path can be specified via the `CONFIG_PATH` environment variable (default `config.json`).
 The file should list one or more polling sources. Each source can optionally define a `version` field to select the SNMP protocol version (supported values are `1` and `2c`; default is `1`):
 
 ```json
@@ -49,6 +49,19 @@ historical data is returned. The value is a Go style duration such as `24h`:
     }
   ]
 }
+```
+Graphs can optionally be arranged into named groups when using a YAML configuration:
+
+```yaml
+sources:
+  - { name: "Internal sensor", ... }
+graphs:
+  - name: "Room Temp"
+    sources: ["Internal sensor"]
+groups:
+  - name: Temperatures
+    graphs:
+      - "Room Temp"
 ```
 
 Additional options can still be set through environment variables:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.23
 require (
 	github.com/gosnmp/gosnmp v1.36.0
 	go.etcd.io/bbolt v1.3.8
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require golang.org/x/sys v0.4.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -10,5 +10,7 @@ go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
 go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,69 @@
+sources:
+  - name: Internal sensor - Temp(C)
+    host: 192.168.1.253
+    community: public
+    oid: 1.3.6.1.4.1.20916.1.10.1.1.1.0
+    version: "1"
+    units: C
+    type: temperature
+    color: "#ff0000"
+  - name: External sensor - Temp(C)
+    host: 192.168.1.253
+    community: public
+    oid: 1.3.6.1.4.1.20916.1.10.1.2.1.0
+    version: "1"
+    units: C
+    type: temperature
+    color: "#0000ff"
+  - name: External sensor - Relative Humidity(%)
+    host: 192.168.1.253
+    community: public
+    oid: 1.3.6.1.4.1.20916.1.10.1.2.3.0
+    version: "1"
+    units: "%"
+    type: humidity
+    color: "#00aa00"
+
+graphs:
+  - name: Room vs Switch Output Temp
+    sources:
+      - Internal sensor - Temp(C)
+      - External sensor - Temp(C)
+    timespan: 24h
+  - name: Switch Output Temp vs Humidity
+    sources:
+      - External sensor - Temp(C)
+      - External sensor - Relative Humidity(%)
+    timespan: 24h
+  - name: Room Temp
+    sources:
+      - Internal sensor - Temp(C)
+    timespan: 72h
+  - name: Switch Output Temp
+    sources:
+      - External sensor - Temp(C)
+    timespan: 72h
+  - name: Humidity
+    sources:
+      - External sensor - Relative Humidity(%)
+    timespan: 72h
+  - name: Temps vs Humidity
+    sources:
+      - Internal sensor - Temp(C)
+      - External sensor - Temp(C)
+      - External sensor - Relative Humidity(%)
+    timespan: 24h
+
+groups:
+  - name: Temperatures
+    graphs:
+      - Room Temp
+      - Switch Output Temp
+  - name: Humidity
+    graphs:
+      - Humidity
+  - name: Comparisons
+    graphs:
+      - Room vs Switch Output Temp
+      - Switch Output Temp vs Humidity
+      - Temps vs Humidity


### PR DESCRIPTION
## Summary
- add a YAML configuration example with graph groups
- support YAML in backend configuration loader
- expose groups from the `/api/data` endpoint
- display graphs grouped in the frontend

## Testing
- `npm install`
- `npm run build`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880b32fa028832b9119029ff680b01b