### PR TITLE
Fix tab labels

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -152,7 +152,14 @@
 
 <Tabs style="underline">
   {#each groups as grp, i}
-    <TabItem open={i === activeTab} on:click={() => {activeTab = i; fetchData();}}>{grp.name}</TabItem>
+    <TabItem
+      title={grp.name}
+      open={i === activeTab}
+      on:click={() => {
+        activeTab = i;
+        fetchData();
+      }}
+    />
   {/each}
 </Tabs>
 <div id="dashboard">


### PR DESCRIPTION
## Summary
- ensure tabs display group names instead of the default label

## Testing
- `npm run build` in `frontend`
- `go test ./...` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68814fcc0ef0832ba54d69c201b50379