### PR TITLE
feat: decode numeric SNMP trap values

### DIFF
--- a/backend/trapdecode.go
+++ b/backend/trapdecode.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// decodeTrapValue converts SNMP trap values represented either as dotted
+// decimal addresses (e.g. "0.0.0.0") or as a list of bytes such as
+// "[70 71 54]" into a human readable string.  Numeric arrays are treated as
+// ASCII codes.
+func decodeTrapValue(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "[") && strings.HasSuffix(raw, "]") {
+		fields := strings.Fields(strings.Trim(raw, "[]"))
+		buf := make([]byte, 0, len(fields))
+		for _, f := range fields {
+			v, err := strconv.Atoi(f)
+			if err != nil {
+				// fall back to original representation
+				return raw
+			}
+			buf = append(buf, byte(v))
+		}
+		return string(buf)
+	}
+	return raw
+}
+
+// ExampleTrapDecoding demonstrates decoding of a typical FortiGate trap
+// variable. The trap values are commonly provided by tools like snmptrapd in
+// the format used in decodeTrapValue.
+func ExampleTrapDecoding() {
+	trap := "[70 71 54 72 49 70 84 66 50 50 57 48 49 52 48 53]"
+	fmt.Println(decodeTrapValue(trap))
+	// Output: FG6H1FTB22901405
+}

--- a/backend/trapdecode_test.go
+++ b/backend/trapdecode_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestDecodeTrapValue(t *testing.T) {
+	got := decodeTrapValue("[70 71 54 72 49 70 84 66 50 50 57 48 49 52 48 53]")
+	if got != "FG6H1FTB22901405" {
+		t.Fatalf("unexpected decode result: %q", got)
+	}
+	if decodeTrapValue("0.0.0.0") != "0.0.0.0" {
+		t.Fatalf("dotted values should be preserved")
+	}
+}

--- a/backend/trapdecode_test.go
+++ b/backend/trapdecode_test.go
@@ -11,3 +11,18 @@ func TestDecodeTrapValue(t *testing.T) {
 		t.Fatalf("dotted values should be preserved")
 	}
 }
+
+func TestRenderTrap(t *testing.T) {
+	vars := []trapVar{
+		{OID: ".1.3.6.1.2.1.1.3.0", Value: "57587075"},
+		{OID: ".1.3.6.1.4.1.12356.100.1.1.1.0", Value: "[70 71 54 72 49 70 84 66 50 50 57 48 49 52 48 53]"},
+	}
+	got, err := renderTrap("172.18.255.67", vars)
+	if err != nil {
+		t.Fatalf("renderTrap returned error: %v", err)
+	}
+	want := "172.18.255.67:\n  .1.3.6.1.2.1.1.3.0 => 57587075\n  .1.3.6.1.4.1.12356.100.1.1.1.0 => FG6H1FTB22901405\n"
+	if got != want {
+		t.Fatalf("unexpected render output:\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add `decodeTrapValue` helper for turning numeric byte arrays from traps into readable strings
- test decoding for FortiGate trap example

## Testing
- `go test`


------
https://chatgpt.com/codex/tasks/task_e_68abd0d76aa4832b8a43a10d64733764